### PR TITLE
Fix handling of intermediate frame.

### DIFF
--- a/SwatInc.Lis.Lis01A2/Services/Lis01A2Connection.cs
+++ b/SwatInc.Lis.Lis01A2/Services/Lis01A2Connection.cs
@@ -156,6 +156,7 @@ namespace SwatInc.Lis.Lis01A2.Services
                                                     if (_lastFrameWasIntermediate)
                                                     {
                                                         _tempIntermediateFrameBuffer = $"{_tempIntermediateFrameBuffer}{cleanReceiveBuffer}";
+                                                        continue;
                                                     }
                                                     else if (OnReceiveString != null)
                                                     {


### PR DESCRIPTION
When the last frame was immediate frame, it should append  newly received frame buffer to __tempIntermediateFrameBuffer.